### PR TITLE
ユーザー新規登録

### DIFF
--- a/app/assets/stylesheets/common.css
+++ b/app/assets/stylesheets/common.css
@@ -132,3 +132,18 @@ h2{
   margin-top: 10px;
   text-align: center;
 }
+
+.transition-link {
+  text-align: center;
+}
+
+.custom-link {
+  font-size: 12px;
+  color: #1B5678;
+  text-decoration: none;
+}
+
+.custom-link:hover {
+  color: black;
+  text-decoration: none;
+}

--- a/app/assets/stylesheets/signup.css
+++ b/app/assets/stylesheets/signup.css
@@ -1,0 +1,57 @@
+.signup-form {
+  margin: auto;
+  width: 480px;
+  height: 145px;
+}
+
+.signup-h2 {
+  margin: 50px auto;
+  width: 324px;
+  height: 48px;
+  text-align: center;
+  font-size: 36px;
+}
+
+.signup-field {
+  border: none;
+  border-bottom: 1.5px solid #ccc;
+  width: 480px;
+  height: 38px;
+  font-size: 16px;
+  background-color: white;
+}
+
+.minimum-length {
+  font-size: 12px;
+  color: gray;
+}
+
+.signup-actions {
+  margin-top: 400px;
+  margin-bottom: 10px;
+  text-align: center;
+}
+
+.signup-button {
+  width: 200px;
+  height: 53px;
+  text-decoration: none;
+  border: none;
+  border-radius: 4px;
+  background-color: #1B5678;
+  color: white;
+}
+
+#error_explanation {
+  width: max-content;
+  color: red;
+}
+
+.error-explanation-h2 {
+  font-size: 20px;
+}
+
+.error-explanation-ul {
+  font-size: 16px;
+}
+

--- a/app/assets/stylesheets/top.css
+++ b/app/assets/stylesheets/top.css
@@ -46,7 +46,9 @@
   width: 521px;
   height: 81px;
   padding-right: 100px;
+  padding-bottom: 20px;
   font-size: 18px;
+  word-wrap: break-word;
 }
 
 .top-profile-actions {

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -4,16 +4,20 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def new
     build_resource({})
     yield resource if block_given?
+    @custom_message = "ログインに戻る"
     respond_with resource
   end
 
   def create
     super
+    binding.pry 
+      # バリデーションエラー時にフォームを再表示
+      # redirect_to new_user_registration_path
   end
 
   private
 
   def configure_sign_up_params
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute1, :attribute2])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :self_introduction, :image])
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,19 @@
+class Users::RegistrationsController < Devise::RegistrationsController
+  before_action :configure_sign_up_params, only: [:create]
+
+  def new
+    build_resource({})
+    yield resource if block_given?
+    respond_with resource
+  end
+
+  def create
+    super
+  end
+
+  private
+
+  def configure_sign_up_params
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute1, :attribute2])
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,11 +11,11 @@ class UsersController < ApplicationController
         @data = {}
 
         @categories.each do |category|
-          skills = Skill.where(category_id: category.id)
+          sskills = @user.skills.where(category_id: category.id)
           monthly_skill_levels = {
-            "先々月" => skills.where(updated_at: 2.months.ago.beginning_of_month).sum(:skill_level),
-            "先月" => skills.where(updated_at: 1.months.ago.beginning_of_month).sum(:skill_level),
-            "今月" => skills.where(updated_at: Time.current.beginning_of_month..Time.current.end_of_month).sum(:skill_level)
+            "先々月" => @user.skills.where(updated_at: 2.months.ago.beginning_of_month).sum(:skill_level),
+            "先月" => @user.skills.where(updated_at: 1.months.ago.beginning_of_month).sum(:skill_level),
+            "今月" => @user.skills.where(updated_at: Time.current.beginning_of_month..Time.current.end_of_month).sum(:skill_level)
           }
 
           @data[category.name] = monthly_skill_levels

--- a/app/helpers/users/registrations_helper.rb
+++ b/app/helpers/users/registrations_helper.rb
@@ -1,0 +1,2 @@
+module Users::RegistrationsHelper
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
   has_many :skills
   has_one_attached :image
 
+  validates :name, presence: true
   validates :email, presence: true, uniqueness: true
   validates :password, presence: true, if: -> { password.present? }
   validates :self_introduction, presence: true, length: { minimum: 50, maximum: 200 }

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,29 +1,100 @@
-<h2>Sign up</h2>
+<h2 class="signup-h2">新規登録</h2>
+<div class="signup-form">
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+    <div class="field" data-turbo="false">
+      <%= label_tag :name, "名前", class:"label-tag" %>
+      <%= f.text_field :name, autofocus: true, class:"signup-field" %>
+    </div>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <div class="field" data-turbo="false">
+      <%= f.label :email, class:"label-tag" %>
+      <%= f.email_field :email, autocomplete: "email", class:"signup-field" %>
+    </div>
+
+    <div class="field" data-turbo="false">
+      <%= f.label :password, class:"label-tag" %>
+      <%= f.password_field :password, autocomplete: "new-password", class: "signup-field" %>
+      <% if @minimum_password_length %>
+        <p class="minimum-length"><%= @minimum_password_length %> 文字以上で入力してください</p>
+      <% end %>
+    </div>
+
+    <div class="field" data-turbo="false">
+      <%= f.label :password_confirmation, class:"label-tag" %>
+      <%= f.password_field :password_confirmation, class: "signup-field" %>
+    </div>
+
+    <div class="field" data-turbo="false">
+        <%= label_tag :self_introduction, "自己紹介文", class: "label-tag" %>
+        <%= f.text_area :self_introduction, rows: 5, class: "text-area" %>
+        <p class="character-limit">50文字以上、200文字未満で入力してください</p>
+    </div>
+
+    <div class="image-field" data-turbo="false">
+      <%= label_tag :self_introduction, "アバター画像", class: "label-tag" %><br />
+      <%= f.label :image, "画像ファイルを添付する", class: "upload-button", for: "image-upload-field" %>
+      <%= f.file_field :image, class: "base-button", id: "image-upload-field" %>
+        <div id="image-preview-container">
+          <img id="image-preview" src="#" />
+        </div>
+    </div>
+
+    <div class="signup-actions">
+      <%= f.submit "新規登録", class:"signup-button" %>
+    </div>
+  <% end %>
+
+  <div class="transition-link">
+    <%= link_to "ログインに戻る", new_user_session_path, class: "custom-link" %>
   </div>
+</div>
 
-  <div class="field">
-    <%= f.label :password %>
-    <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> characters minimum)</em>
-    <% end %><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-  </div>
+<script>
+document.addEventListener('DOMContentLoaded', () => {
 
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
+  const contentElement = document.querySelector('.content');
+  const imagePreviewContainer = document.getElementById('image-preview-container');
+  const fileInput = document.getElementById('image-upload-field');
+  const imagePreview = document.getElementById('image-preview');
 
-  <div class="actions">
-    <%= f.submit "Sign up" %>
-  </div>
-<% end %>
+  function setContentHeight() {
+    contentElement.style.height = '1400px';
 
-<%= render "devise/shared/links" %>
+    // バリデーションエラーが発生した場合の高さを設定
+    if (error_explanation) {
+      contentElement.style.height = '1600px';
+    }
+  }
+
+  window.addEventListener('DOMContentLoaded', () => {
+    const imagePreview = document.getElementById('image-preview');
+    imagePreview.src = '<%= asset_path("default_avatar.png") %>';
+    imagePreview.style.width = '260px';
+    imagePreview.style.height = '260px';
+    imagePreview.style.border = '0.5px solid #ccc';
+    imagePreview.style.borderRadius = '50%';
+
+    setContentHeight();
+  });
+
+  fileInput.addEventListener('change', (e) => {
+    const file = e.target.files[0];
+
+    if (file) {
+      const reader = new FileReader();
+
+      reader.onload = (e) => {
+        imagePreview.src = e.target.result;
+        setContentHeight();
+      };
+
+      reader.readAsDataURL(file);
+    } else {
+      imagePreview.src = 'app/assets/images/default_avatar.png';
+      setContentHeight();
+    }
+  });
+});
+</script>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -32,4 +32,7 @@
       <%= f.submit "ログインする", class: "login-submit-button" %>
     </div>
   <% end %>
+  <div class="transition-link">
+    <%= link_to "新規登録する", new_user_registration_path, class: "custom-link" %>
+  </div>
 </div>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,14 +1,14 @@
 <% if resource.errors.any? %>
   <div id="error_explanation" data-turbo-cache="false">
-    <h2>
+    <h2 class="error-explanation-h2">
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,
                  resource: resource.class.model_name.human.downcase)
        %>
     </h2>
-    <ul>
+    <ul class="error-explanation-ul">
       <% resource.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
+        <li class="error-explanation-li"><%= message %></li>
       <% end %>
     </ul>
   </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -10,8 +10,8 @@
     <div class="introduction-container">
       <h2 class="introduction-h2">自己紹介</h2>
       <hr class="underline">
-      <% @users.each do |user| %>
-        <p class="introduction-text"><%= user.self_introduction %></p>
+      <% if @user == current_user %>
+        <p class="introduction-text"><%= @user.self_introduction %></p>
       <% end %>
       <div class="top-profile-actions">
         <%= button_to "自己紹介を編集する", edit_user_path(current_user), method: :get, class:"profile-edit-button" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
 
   devise_for :users, controllers: {
     sessions: 'users/sessions',
+    registrations: 'users/registrations'
   }
 
   delete '/users/sign_out' => 'devise/sessions#destroy'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,5 +14,5 @@ Rails.application.routes.draw do
     resources :skills
   end
 
-  resources :users
+  resources :users, only: [:index, :show, :edit, :update] 
 end

--- a/test/controllers/users/registrations_controller_test.rb
+++ b/test/controllers/users/registrations_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Users::RegistrationsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## チケットへのリンク
完了済み
* https://prum.backlog.com/view/PRUM_ACADEMY-925

## やったこと

* 新規登録機能
* 新規登録〜ログイン間のページ遷移
* 新規登録のバリデーション
* バリデーション発生時のcontent要素の高さ調整（javascript)
* トップページの表示に関する処理修正

## やらないこと

* バリデーションのエラーメッセージ内容修正
（例）「メールアドレスメールアドレスを入力してください」と表示されてしまう。
→別のPRで対応

* バリデーション発生した時、http://localhost:3000/users　のURLになる。リロードするとログイン画面にリダイレクトする
→http://localhost:3000/users/sign_up　でずっと表示させたいが、リロードせず再入力すれば登録はできる。
不具合なのか（deviseの）仕様なのかの切り分けも含めて、修正の優先度低いので、別途対応。

## できるようになること（ユーザ目線）

* ユーザーが新規登録できる
* 不正な値の場合、エラーメッセージを確認できる
* ログイン画面もしくは新規登録画面にリンクから遷移できる
* 新規登録後、リダイレクトされてトップページを見れる

## できなくなること（ユーザ目線）
* なし

## 動作確認

1. http://localhost:3000/users/sign_up　にアクセス（ログインページの「新規登録する」ボタンから）
2. 各項目を適切な値で入力して新規登録が成功すること（トップページにリダイレクトする）
3. 不正な値を入力して新規登録が失敗し、エラーメッセージが表示されること（必須項目の未入力や文字数制限にかかる）
4. 再入力後、新規登録が成功する

## その他
* 追加の実装です